### PR TITLE
fix: author link referencing name instead of slug

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -28,6 +28,7 @@ export async function parseAuthors(authors: string[]) {
     try {
       const author = await getEntry('authors', slug)
       return {
+        slug,
         name: author?.data?.name || slug,
         avatar: author?.data?.avatar || '/static/logo.png',
         isRegistered: !!author,
@@ -35,6 +36,7 @@ export async function parseAuthors(authors: string[]) {
     } catch (error) {
       console.error(`Error fetching author with slug ${slug}:`, error)
       return {
+        slug,
         name: slug,
         avatar: '/static/logo.png',
         isRegistered: false,

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -103,7 +103,7 @@ const authors = await parseAuthors(post.data.authors ?? [])
                       />
                       {author.isRegistered ? (
                         <Link
-                          href={`/authors/${author.name}`}
+                          href={`/authors/${author.slug}`}
                           underline
                           class="text-foreground"
                         >


### PR DESCRIPTION
Since an author's slug can differ from their specified `name`, for example `johndoe.md` containing `name: 'John Doe'`, the link from a post to the author's page can be mismatched causing unintentional 404's.

btw: I absolutely love this template