### PR TITLE
fix: center preview image in BlogCard component

### DIFF
--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -28,7 +28,7 @@ const authors = await parseAuthors(entry.data.authors ?? [])
   >
     {
       entry.data.image && (
-        <div class="max-w-3xs sm:shrink-0">
+        <div class="max-w-3xs sm:shrink-0 mx-auto">
           <Image
             src={entry.data.image}
             alt={entry.data.title}


### PR DESCRIPTION
Horizontally centered the image in BlogCard for small screen devices