### PR TITLE
fix: post and project banner orientation on mobile devices

### DIFF
--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -34,7 +34,7 @@ const subpostCount = !isSubpost(entry.id) ? await getSubpostCount(entry.id) : 0
   >
     {
       entry.data.image && (
-        <div class="max-w-3xs sm:shrink-0">
+        <div class="w-full sm:max-w-3xs sm:shrink-0">
           <Image
             src={entry.data.image}
             alt={entry.data.title}

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -23,7 +23,7 @@ const { project } = Astro.props
   >
     {
       project.data.image && (
-        <div class="max-w-3xs sm:shrink-0">
+        <div class="w-full sm:max-w-3xs sm:shrink-0">
           <Image
             src={project.data.image}
             alt={project.data.name}


### PR DESCRIPTION
Just a quick thing - it might just be a design choice in which case feel free to close this PR. I just felt that the updated version looked better in general. I did this in my fork hence thought of raising it here as well.

The banner images look like this currently on mobile devices.

 
<img width="300" height="1080" alt="astro-erudite vercel app_about(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/3f3458ac-96d1-4b8a-beb5-1def81efff2e" />

The small updates in the PR make them look like this.

<img width="300" height="1180" alt="localhost_1234_about(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/37e38d15-5905-4c7a-9b9f-2a78e2292074" />

Thank you!

