### PR TITLE
fix: prevent duplicate theme declaration in client reruns

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -16,16 +16,18 @@ import { Icon } from 'astro-icon/components'
 </Button>
 
 <script is:inline data-astro-rerun>
-  const theme = (() => {
-    const stored = localStorage?.getItem('theme') ?? ''
-    if (['dark', 'light'].includes(stored)) return stored
-    return window.matchMedia('(prefers-color-scheme: dark)').matches
-      ? 'dark'
-      : 'light'
-  })()
+  (() => {
+    const theme = (() => {
+      const stored = localStorage?.getItem('theme') ?? ''
+      if (['dark', 'light'].includes(stored)) return stored
+      return window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light'
+    })()
 
-  document.documentElement.setAttribute('data-theme', theme)
-  window.localStorage.setItem('theme', theme)
+    document.documentElement.setAttribute('data-theme', theme)
+    window.localStorage.setItem('theme', theme)
+  })()
 </script>
 
 <script>


### PR DESCRIPTION
在使用 **<ClientRouter />** 进行页面切换时，**<script is:inline data-astro-rerun>** 中的代码会被多次执行。

<img width="528" height="232" alt="截屏2025-09-29 11 10 28" src="https://github.com/user-attachments/assets/d29874e0-fa98-4315-9dc0-d09c6f08894b" />
