### PR TITLE
Add chai-pin-zheng.xyz example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Below are some fantastic examples of websites based on this template. If you wis
 | [Off by One](https://justoffbyone.com) | [@cduruk](https://github.com/cduruk) | engineering, blog | [→](https://github.com/cduruk/offbyone) |
 | [holywater.dev](https://holywater.dev) | [@holywater2372](https://github.com/holywater2372) | cybersecurity, blog | [→](https://github.com/holywater2372/holywater.dev) |
 | [theinfinull.com](https://theinfinull.com) | [@theinfinull](https://github.com/theinfinull) | dev, portfolio, blog | [→](https://github.com/theinfinull/portfolio) |
+| [chai-pin-zheng.xyz](https://www.chai-pin-zheng.xyz/) | [@Ducksss](https://github.com/Ducksss) | portfolio, interactive, , blog, ascii | [→](https://github.com/Ducksss/ascii-astro-erudite) |
+
 ## Features
 
 - [Astro](https://astro.build/)'s [Islands](https://docs.astro.build/en/concepts/islands/) architecture for selective hydration and client-side interactivity while maintaining fast static site rendering.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Below are some fantastic examples of websites based on this template. If you wis
 | [Off by One](https://justoffbyone.com) | [@cduruk](https://github.com/cduruk) | engineering, blog | [→](https://github.com/cduruk/offbyone) |
 | [holywater.dev](https://holywater.dev) | [@holywater2372](https://github.com/holywater2372) | cybersecurity, blog | [→](https://github.com/holywater2372/holywater.dev) |
 | [theinfinull.com](https://theinfinull.com) | [@theinfinull](https://github.com/theinfinull) | dev, portfolio, blog | [→](https://github.com/theinfinull/portfolio) |
-| [chai-pin-zheng.xyz](https://www.chai-pin-zheng.xyz/) | [@Ducksss](https://github.com/Ducksss) | portfolio, interactive, , blog, ascii | [→](https://github.com/Ducksss/ascii-astro-erudite) |
+| [chai-pin-zheng.xyz](https://www.chai-pin-zheng.xyz/) | [@Ducksss](https://github.com/Ducksss) | portfolio, interactive, blog, ascii | [→](https://github.com/Ducksss/ascii-astro-erudite) |
 
 ## Features
 


### PR DESCRIPTION
## Summary

- add [chai-pin-zheng.xyz](https://www.chai-pin-zheng.xyz/) to the README Community examples table
- categorize it as `portfolio, interactive, blog, ascii`
- append the new entry without reordering existing examples

## Notes

This site is a customized portfolio/blog built from `astro-erudite`! Cheers from Singapore 🇸🇬
