### PR TITLE
feat: add mdx image components and authoring snippets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/
 .astro/
 node_modules/
+data/image-metadata.sqlite
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/.vscode/mdx.code-snippets
+++ b/.vscode/mdx.code-snippets
@@ -1,0 +1,60 @@
+{
+  "Import Writing Components": {
+    "scope": "mdx,markdown",
+    "prefix": ["imports", "import-writing"],
+    "body": [
+      "import Callout from '@/components/callout.astro'",
+      "import Figure from '@/components/figure.astro'",
+      "import ImageGrid from '@/components/image-grid.astro'"
+    ],
+    "description": "Import common MDX writing components"
+  },
+  "Import Callout": {
+    "scope": "mdx,markdown",
+    "prefix": "import-callout",
+    "body": ["import Callout from '@/components/callout.astro'"],
+    "description": "Import Callout component"
+  },
+  "Import Figure": {
+    "scope": "mdx,markdown",
+    "prefix": "import-figure",
+    "body": ["import Figure from '@/components/figure.astro'"],
+    "description": "Import Figure component"
+  },
+  "Import ImageGrid": {
+    "scope": "mdx,markdown",
+    "prefix": "import-imggrid",
+    "body": ["import ImageGrid from '@/components/image-grid.astro'"],
+    "description": "Import ImageGrid component"
+  },
+  "Figure": {
+    "scope": "mdx,markdown",
+    "prefix": "fig",
+    "body": [
+      "<Figure",
+      "  src=\"${1:https://example.com/image.webp}\"",
+      "  caption=\"${2:Image caption}\"",
+      "/>"
+    ],
+    "description": "Insert a Figure block"
+  },
+  "ImageGrid": {
+    "scope": "mdx,markdown",
+    "prefix": ["image", "imggrid"],
+    "body": [
+      "<ImageGrid",
+      "  images={[",
+      "    {",
+      "      src: '${1:https://example.com/image-a.webp}',",
+      "      caption: '${2:First image}',",
+      "    },",
+      "    {",
+      "      src: '${3:https://example.com/image-b.webp}',",
+      "      caption: '${4:Second image}',",
+      "    },",
+      "  ]}",
+      "/>"
+    ],
+    "description": "Insert an ImageGrid block"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "[markdown]": {
+    "editor.snippetSuggestions": "top",
+    "editor.suggestSelection": "first",
+    "editor.tabCompletion": "on"
+  },
+  "[mdx]": {
+    "editor.snippetSuggestions": "top",
+    "editor.suggestSelection": "first",
+    "editor.tabCompletion": "on"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ This is a list of the various technologies used to build this template:
    | Command            | Description                                                     |
    | ------------------ | --------------------------------------------------------------- |
    | `npm run start`    | Alias for `npm run dev`                                         |
-   | `npm run build`    | Run type checking and build the project                         |
+   | `npm run build`    | Sync image metadata, run type checking, and build the project   |
    | `npm run preview`  | Previews the built project                                      |
    | `npm run astro`    | Run Astro CLI commands                                          |
    | `npm run prettier` | Blanket format all files using [Prettier](https://prettier.io/) |
@@ -210,6 +210,37 @@ The blog post schema is defined as follows:
 | `tags`        | `string[]`      | Preferably use kebab-case for these.                                                                                                                                            | Optional |
 | `authors`     | `string[]`      | If the author has a profile, use the id associated with their Markdown file in `src/content/authors/` (e.g. if their file is named `jane-doe.md`, use `jane-doe` in the array). | Optional |
 | `draft`       | `boolean`       | Defaults to `false` if not provided.                                                                                                                                            | Optional |
+
+### MDX image components
+
+Use `Figure` for a single captioned image and `ImageGrid` for a responsive image group. Both components support lazy loading, stable aspect-ratio placeholders, captions, and PhotoSwipe lightbox previews.
+
+```mdx
+import Figure from '@/components/figure.astro'
+import ImageGrid from '@/components/image-grid.astro'
+
+<Figure
+  src="https://example.com/image.webp"
+  caption="A captioned image"
+/>
+
+<ImageGrid
+  images={[
+    {
+      src: 'https://example.com/image-a.webp',
+      caption: 'First image',
+    },
+    {
+      src: 'https://example.com/image-b.webp',
+      caption: 'Second image',
+    },
+  ]}
+/>
+```
+
+Remote image dimensions are synced by `npm run sync:image-metadata`, which stores a local SQLite cache at `data/image-metadata.sqlite` and writes `src/generated/image-metadata.ts` for the components to read during rendering. `npm run dev` and `npm run build` run the sync automatically, so MDX authors usually only need to provide `src` and `caption`. If an image cannot be measured, the components fall back to a default placeholder size.
+
+VS Code users can use the included MDX snippets: type `fig` for `Figure`, `imggrid` for `ImageGrid`, `import-figure` for the single-image import, or `import-imggrid` for the grid import.
 
 ### Authors
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "@expressive-code/plugin-line-numbers": "^0.40.2",
         "@iconify-json/lucide": "^1.2.26",
         "@shikijs/rehype": "^3.4.0",
-        "@tailwindcss/vite": "^4.0.7",
+        "@tailwindcss/vite": "4.2.1",
         "@types/react": "19.0.0",
         "@types/react-dom": "19.0.0",
         "astro": "6.0.2",
@@ -23,6 +23,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.469.0",
+        "photoswipe": "^5.4.4",
         "radix-ui": "^1.3.4",
         "react": "19.0.0",
         "react-dom": "19.0.0",
@@ -31,6 +32,7 @@
         "rehype-katex": "^7.0.1",
         "remark-emoji": "^5.0.1",
         "remark-math": "^6.0.0",
+        "sharp": "^0.34.5",
         "tailwind-merge": "^3.3.0",
         "tailwindcss": "^4.1.7",
         "typescript": "^5.8.3",
@@ -1105,6 +1107,8 @@
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
+    "photoswipe": ["photoswipe@5.4.4", "", {}, "sha512-WNFHoKrkZNnvFFhbHL93WDkW3ifwVOXSW3w1UuZZelSmgXpIGiZSNlZJq37rR8YejqME2rHs9EhH9ZvlvFH2NA=="],
 
     "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
 

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "version": "1.6.3",
   "private": true,
   "scripts": {
-    "dev": "astro dev",
-    "start": "astro dev",
-    "build": "astro check && astro build",
+    "dev": "npm run sync:image-metadata && astro dev",
+    "start": "npm run dev",
+    "build": "npm run sync:image-metadata && astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "prettier": "prettier --write **/*.{ts,tsx,css,astro} --ignore-path .gitignore"
+    "prettier": "prettier --write **/*.{ts,tsx,css,astro} --ignore-path .gitignore",
+    "sync:image-metadata": "node scripts/sync-image-metadata.mjs"
   },
   "dependencies": {
     "@astrojs/check": "0.9.7",
@@ -22,7 +23,7 @@
     "@expressive-code/plugin-line-numbers": "^0.40.2",
     "@iconify-json/lucide": "^1.2.26",
     "@shikijs/rehype": "^3.4.0",
-    "@tailwindcss/vite": "^4.0.7",
+    "@tailwindcss/vite": "4.2.1",
     "@types/react": "19.0.0",
     "@types/react-dom": "19.0.0",
     "astro": "6.0.2",
@@ -30,6 +31,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.469.0",
+    "photoswipe": "^5.4.4",
     "radix-ui": "^1.3.4",
     "react": "19.0.0",
     "react-dom": "19.0.0",
@@ -38,6 +40,7 @@
     "rehype-katex": "^7.0.1",
     "remark-emoji": "^5.0.1",
     "remark-math": "^6.0.0",
+    "sharp": "^0.34.5",
     "tailwind-merge": "^3.3.0",
     "tailwindcss": "^4.1.7",
     "typescript": "^5.8.3"

--- a/scripts/sync-image-metadata.mjs
+++ b/scripts/sync-image-metadata.mjs
@@ -1,0 +1,466 @@
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import sharp from 'sharp'
+
+const contentRoot = path.resolve(
+  process.env.IMAGE_METADATA_CONTENT_ROOT || 'src/content/blog',
+)
+const databasePath = path.resolve(
+  process.env.IMAGE_METADATA_DATABASE_PATH || 'data/image-metadata.sqlite',
+)
+const generatedPath = path.resolve(
+  process.env.IMAGE_METADATA_GENERATED_PATH ||
+    'src/generated/image-metadata.ts',
+)
+const fixturePath = process.env.IMAGE_METADATA_FIXTURE_PATH
+  ? path.resolve(process.env.IMAGE_METADATA_FIXTURE_PATH)
+  : null
+
+const defaultHeaders = {
+  'user-agent': 'astro-erudite-image-metadata/1.0',
+  accept: 'image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8',
+}
+const rangeEnd = Number(process.env.IMAGE_METADATA_RANGE_END || 65535)
+const requestTimeoutMs = Number(process.env.IMAGE_METADATA_TIMEOUT_MS || 10000)
+const concurrency = Number(process.env.IMAGE_METADATA_CONCURRENCY || 6)
+const allowFailures = process.env.IMAGE_METADATA_ALLOW_FAILURES === '1'
+const refresh = process.argv.includes('--refresh')
+
+async function listMdxFiles(dir) {
+  const entries = await import('node:fs/promises').then((fs) =>
+    fs.readdir(dir, { withFileTypes: true }),
+  )
+  const files = []
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await listMdxFiles(fullPath)))
+      continue
+    }
+    if (entry.isFile() && entry.name.endsWith('.mdx')) {
+      files.push(fullPath)
+    }
+  }
+
+  return files
+}
+
+function stripCodeBlocks(markdown) {
+  const lines = markdown.split('\n')
+  let inFence = false
+
+  return lines
+    .map((line) => {
+      if (/^\s*```/.test(line)) {
+        inFence = !inFence
+        return ''
+      }
+      if (inFence) {
+        return ''
+      }
+      return line
+    })
+    .join('\n')
+}
+
+function collectImageComponentBlocks(markdown) {
+  const blocks = []
+  const lines = markdown.split('\n')
+  let currentBlock = null
+
+  for (const line of lines) {
+    if (/^<(?:Figure|ImageGrid)\b/.test(line)) {
+      currentBlock = [line]
+      if (/^\s*\/>/.test(line)) {
+        blocks.push(currentBlock.join('\n'))
+        currentBlock = null
+      }
+      continue
+    }
+
+    if (!currentBlock) continue
+
+    currentBlock.push(line)
+    if (/^\s*\/>/.test(line)) {
+      blocks.push(currentBlock.join('\n'))
+      currentBlock = null
+    }
+  }
+
+  return blocks
+}
+
+function collectImageUrls(markdown) {
+  const urls = new Set()
+  const searchableMarkdown = stripCodeBlocks(markdown)
+  const markdownImagePattern =
+    /!\[[^\]]*]\((https?:\/\/[^)\s]+)(?:\s+['"][^'"]*['"])?\)/g
+  const componentSrcPattern = /\bsrc\s*[:=]\s*(['"])(https?:\/\/[^'"]+)\1/g
+
+  let markdownImage
+  while (
+    (markdownImage = markdownImagePattern.exec(searchableMarkdown)) !== null
+  ) {
+    urls.add(markdownImage[1])
+  }
+
+  for (const componentBlock of collectImageComponentBlocks(
+    searchableMarkdown,
+  )) {
+    let componentSrc
+    while ((componentSrc = componentSrcPattern.exec(componentBlock)) !== null) {
+      urls.add(componentSrc[2])
+    }
+  }
+
+  return urls
+}
+
+async function collectAllImageUrls() {
+  const files = await listMdxFiles(contentRoot)
+  const urls = new Set()
+
+  for (const file of files) {
+    const markdown = await readFile(file, 'utf8')
+    for (const url of collectImageUrls(markdown)) {
+      urls.add(url)
+    }
+  }
+
+  return [...urls].sort()
+}
+
+async function openDatabase() {
+  await mkdir(path.dirname(databasePath), { recursive: true })
+  const db = new DatabaseSync(databasePath)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS image_metadata (
+      url TEXT PRIMARY KEY,
+      width INTEGER,
+      height INTEGER,
+      content_type TEXT,
+      etag TEXT,
+      last_modified TEXT,
+      checked_at TEXT NOT NULL,
+      status TEXT NOT NULL,
+      error TEXT
+    ) STRICT;
+  `)
+  return db
+}
+
+async function readHead(url) {
+  try {
+    const response = await fetch(url, {
+      method: 'HEAD',
+      headers: defaultHeaders,
+      redirect: 'follow',
+      signal: AbortSignal.timeout(requestTimeoutMs),
+    })
+
+    if (!response.ok) return {}
+
+    return {
+      contentType: response.headers.get('content-type') || undefined,
+      etag: response.headers.get('etag') || undefined,
+      lastModified: response.headers.get('last-modified') || undefined,
+    }
+  } catch {
+    return {}
+  }
+}
+
+async function fetchBuffer(url, { range = true } = {}) {
+  const headers = {
+    ...defaultHeaders,
+    ...(range ? { range: `bytes=0-${rangeEnd}` } : {}),
+  }
+  const response = await fetch(url, {
+    headers,
+    redirect: 'follow',
+    signal: AbortSignal.timeout(requestTimeoutMs),
+  })
+
+  if (!response.ok && response.status !== 206) {
+    throw new Error(`HTTP ${response.status}`)
+  }
+
+  return {
+    buffer: Buffer.from(await response.arrayBuffer()),
+    contentType: response.headers.get('content-type') || undefined,
+    etag: response.headers.get('etag') || undefined,
+    lastModified: response.headers.get('last-modified') || undefined,
+    partial: response.status === 206,
+  }
+}
+
+async function mapConcurrent(items, limit, mapper) {
+  const results = new Array(items.length)
+  let nextIndex = 0
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex
+      nextIndex += 1
+      results[index] = await mapper(items[index], index)
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
+  )
+
+  return results
+}
+
+function parseSvgDimensions(buffer) {
+  const text = buffer.toString('utf8', 0, Math.min(buffer.length, 65536))
+  const svg = text.match(/<svg\b[^>]*>/i)?.[0]
+  if (!svg) return null
+
+  const readNumber = (name) => {
+    const match = svg.match(new RegExp(`${name}=["']([0-9.]+)(?:px)?["']`, 'i'))
+    return match ? Number(match[1]) : null
+  }
+  const width = readNumber('width')
+  const height = readNumber('height')
+  if (width && height) return { width, height }
+
+  const viewBox = svg.match(
+    /viewBox=["']\s*[-0-9.]+\s+[-0-9.]+\s+([0-9.]+)\s+([0-9.]+)\s*["']/i,
+  )
+  if (!viewBox) return null
+
+  return {
+    width: Number(viewBox[1]),
+    height: Number(viewBox[2]),
+  }
+}
+
+async function readDimensionsFromBuffer(buffer, contentType) {
+  if (contentType?.includes('svg')) {
+    const svgDimensions = parseSvgDimensions(buffer)
+    if (svgDimensions) return svgDimensions
+  }
+
+  const metadata = await sharp(buffer).metadata()
+  if (!metadata.width || !metadata.height) {
+    throw new Error('missing image dimensions')
+  }
+
+  return {
+    width: metadata.width,
+    height: metadata.height,
+  }
+}
+
+async function readFixtureMetadata() {
+  if (!fixturePath) return new Map()
+
+  const payload = JSON.parse(await readFile(fixturePath, 'utf8'))
+  return new Map(Object.entries(payload))
+}
+
+async function readRemoteImageMetadata(url, fixtures) {
+  const fixture = fixtures.get(url)
+  if (fixture) {
+    return {
+      width: fixture.width,
+      height: fixture.height,
+      contentType: fixture.contentType,
+      etag: fixture.etag,
+      lastModified: fixture.lastModified,
+    }
+  }
+
+  const head = await readHead(url)
+  const ranged = await fetchBuffer(url, { range: true })
+  const contentType = ranged.contentType || head.contentType
+
+  try {
+    const dimensions = await readDimensionsFromBuffer(
+      ranged.buffer,
+      contentType,
+    )
+    return {
+      ...dimensions,
+      contentType,
+      etag: ranged.etag || head.etag,
+      lastModified: ranged.lastModified || head.lastModified,
+    }
+  } catch (error) {
+    if (!ranged.partial) throw error
+  }
+
+  const full = await fetchBuffer(url, { range: false })
+  const dimensions = await readDimensionsFromBuffer(
+    full.buffer,
+    full.contentType || contentType,
+  )
+
+  return {
+    ...dimensions,
+    contentType: full.contentType || contentType,
+    etag: full.etag || head.etag,
+    lastModified: full.lastModified || head.lastModified,
+  }
+}
+
+function readCachedMetadata(db, url) {
+  const existing = db
+    .prepare(
+      'SELECT width, height FROM image_metadata WHERE url = ? AND status = ?',
+    )
+    .get(url, 'ok')
+
+  if (existing?.width && existing?.height && !refresh) {
+    return { url, status: 'cached' }
+  }
+
+  return null
+}
+
+async function fetchImageMetadata(url, fixtures) {
+  try {
+    const metadata = await readRemoteImageMetadata(url, fixtures)
+    return { url, status: 'updated', metadata }
+  } catch (error) {
+    return { url, status: 'error', error }
+  }
+}
+
+function saveResult(db, result) {
+  if (result.status === 'cached') return
+
+  if (result.status === 'updated') {
+    const { url, metadata } = result
+    db.prepare(
+      `INSERT INTO image_metadata (
+        url, width, height, content_type, etag, last_modified, checked_at, status, error
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, 'ok', NULL)
+      ON CONFLICT(url) DO UPDATE SET
+        width = excluded.width,
+        height = excluded.height,
+        content_type = excluded.content_type,
+        etag = excluded.etag,
+        last_modified = excluded.last_modified,
+        checked_at = excluded.checked_at,
+        status = 'ok',
+        error = NULL`,
+    ).run(
+      url,
+      metadata.width,
+      metadata.height,
+      metadata.contentType || null,
+      metadata.etag || null,
+      metadata.lastModified || null,
+      new Date().toISOString(),
+    )
+    return
+  }
+
+  if (result.status === 'error') {
+    db.prepare(
+      `INSERT INTO image_metadata (
+        url, width, height, content_type, etag, last_modified, checked_at, status, error
+      ) VALUES (?, NULL, NULL, NULL, NULL, NULL, ?, 'error', ?)
+      ON CONFLICT(url) DO UPDATE SET
+        checked_at = excluded.checked_at,
+        status = 'error',
+        error = excluded.error`,
+    ).run(result.url, new Date().toISOString(), result.error.message)
+  }
+}
+
+async function writeManifest(db, urls) {
+  const rows = db
+    .prepare(
+      `SELECT url, width, height, content_type
+       FROM image_metadata
+       WHERE status = 'ok' AND width IS NOT NULL AND height IS NOT NULL
+       ORDER BY url`,
+    )
+    .all()
+    .filter((row) => urls.includes(row.url))
+
+  const entries = rows
+    .map((row) => {
+      const body = [
+        `width: ${row.width}`,
+        `height: ${row.height}`,
+        row.content_type
+          ? `contentType: ${JSON.stringify(row.content_type)}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(', ')
+      return `  ${JSON.stringify(row.url)}: { ${body} },`
+    })
+    .join('\n')
+
+  const source = `type ImageMetadataEntry = {\n  width: number\n  height: number\n  contentType?: string\n}\n\nexport const imageMetadata: Record<string, ImageMetadataEntry> = {\n${entries}\n}\n\nexport type ImageMetadataUrl = keyof typeof imageMetadata\n`
+  await mkdir(path.dirname(generatedPath), { recursive: true })
+  await writeFile(generatedPath, source)
+}
+
+async function main() {
+  if (!existsSync(contentRoot)) {
+    throw new Error(`Missing content directory: ${contentRoot}`)
+  }
+
+  const urls = await collectAllImageUrls()
+  const db = await openDatabase()
+  const fixtures = await readFixtureMetadata()
+  const cachedResults = new Map()
+  const urlsToFetch = []
+
+  for (const url of urls) {
+    const cached = readCachedMetadata(db, url)
+    if (cached) {
+      cachedResults.set(url, cached)
+      continue
+    }
+    urlsToFetch.push(url)
+  }
+
+  const fetchedResults = await mapConcurrent(urlsToFetch, concurrency, (url) =>
+    fetchImageMetadata(url, fixtures),
+  )
+  const results = urls.map(
+    (url) =>
+      cachedResults.get(url) ||
+      fetchedResults.find((result) => result.url === url),
+  )
+
+  for (const result of results) {
+    saveResult(db, result)
+  }
+
+  await writeManifest(db, urls)
+
+  const summary = results.reduce(
+    (acc, item) => {
+      acc[item.status] = (acc[item.status] || 0) + 1
+      return acc
+    },
+    { total: results.length },
+  )
+  console.log(`Image metadata synced: ${JSON.stringify(summary)}`)
+
+  const failures = results.filter((item) => item.status === 'error')
+  for (const failure of failures) {
+    console.warn(
+      `Image metadata failed: ${failure.url} - ${failure.error.message}`,
+    )
+  }
+  if (failures.length > 0 && !allowFailures) {
+    process.exitCode = 1
+  }
+
+  db.close()
+}
+
+await main()

--- a/src/components/figure.astro
+++ b/src/components/figure.astro
@@ -1,0 +1,51 @@
+---
+import { getImageSize } from '@/lib/image-metadata'
+
+interface Props {
+  src: string
+  alt?: string
+  caption?: string
+  width?: number
+  height?: number
+}
+
+const { src, alt, caption, width: propWidth, height: propHeight } = Astro.props
+const { width, height } = getImageSize(src, propWidth, propHeight)
+const imageAlt = alt || caption || ''
+const aspectStyle = `aspect-ratio: ${width} / ${height}`
+---
+
+<figure class="not-prose my-7">
+  <a
+    href={src}
+    target="_blank"
+    rel="noopener noreferrer"
+    data-pswp-width={width}
+    data-pswp-height={height}
+    data-pswp-caption={caption || imageAlt || undefined}
+    class="bg-muted/30 relative mx-auto block w-full overflow-hidden rounded-md border"
+    style={aspectStyle}
+  >
+    <div
+      aria-hidden="true"
+      class="bg-muted absolute inset-0 size-full animate-pulse transition-opacity duration-300 has-[+img[data-loaded=true]]:animate-none has-[+img[data-loaded=true]]:opacity-0"
+    />
+    <img
+      src={src}
+      alt={imageAlt}
+      width={width}
+      height={height}
+      loading="lazy"
+      decoding="async"
+      class="absolute inset-0 size-full object-contain opacity-0 transition-opacity duration-300 data-[loaded=true]:opacity-100"
+      onload="this.dataset.loaded = 'true'"
+    />
+  </a>
+  {
+    caption && (
+      <figcaption class="text-muted-foreground mt-2 text-center text-sm leading-6">
+        {caption}
+      </figcaption>
+    )
+  }
+</figure>

--- a/src/components/image-grid.astro
+++ b/src/components/image-grid.astro
@@ -1,0 +1,75 @@
+---
+import { getImageSize } from '@/lib/image-metadata'
+import type { FigureImage } from '@/types'
+
+interface Props {
+  images: FigureImage[]
+}
+
+const { images } = Astro.props
+const columnClass =
+  images.length === 1
+    ? 'md:grid-cols-1'
+    : images.length === 2
+      ? 'md:grid-cols-2'
+      : 'md:grid-cols-2 xl:grid-cols-3'
+const imagesWithSize = images.map((image) => ({
+  ...image,
+  ...getImageSize(image.src, image.width, image.height),
+}))
+const frameImage = imagesWithSize.reduce(
+  (tallestImage, image) => {
+    return image.height / image.width > tallestImage.height / tallestImage.width
+      ? image
+      : tallestImage
+  },
+  imagesWithSize[0] || { src: '', width: 1600, height: 1000 },
+)
+const frameAspectStyle = `aspect-ratio: ${frameImage.width || 1600} / ${
+  frameImage.height || 1000
+}`
+---
+
+<div class={`not-prose my-7 grid gap-4 ${columnClass}`}>
+  {
+    imagesWithSize.map((image) => {
+      const { width, height } = image
+      const imageAlt = image.alt || image.caption || ''
+
+      return (
+        <figure class="min-w-0">
+          <a
+            href={image.src}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-pswp-width={width}
+            data-pswp-height={height}
+            data-pswp-caption={image.caption || imageAlt || undefined}
+            class="bg-muted/30 relative block w-full overflow-hidden rounded-md border"
+            style={frameAspectStyle}
+          >
+            <div
+              aria-hidden="true"
+              class="bg-muted absolute inset-0 size-full animate-pulse transition-opacity duration-300 has-[+img[data-loaded=true]]:animate-none has-[+img[data-loaded=true]]:opacity-0"
+            />
+            <img
+              src={image.src}
+              alt={imageAlt}
+              width={width}
+              height={height}
+              loading="lazy"
+              decoding="async"
+              class="absolute inset-0 size-full object-cover opacity-0 transition-opacity duration-300 data-[loaded=true]:opacity-100"
+              onload="this.dataset.loaded = 'true'"
+            />
+          </a>
+          {image.caption && (
+            <figcaption class="text-muted-foreground mt-2 text-center text-sm leading-6">
+              {image.caption}
+            </figcaption>
+          )}
+        </figure>
+      )
+    })
+  }
+</div>

--- a/src/components/photo-swipe.astro
+++ b/src/components/photo-swipe.astro
@@ -1,0 +1,69 @@
+---
+import 'photoswipe/style.css'
+---
+
+<script>
+  import PhotoSwipeLightbox from 'photoswipe/lightbox'
+
+  let lightbox: PhotoSwipeLightbox | null = null
+
+  function initPhotoSwipe() {
+    lightbox?.destroy()
+
+    lightbox = new PhotoSwipeLightbox({
+      gallery: '.prose',
+      children: 'a[data-pswp-width][data-pswp-height]',
+      pswpModule: () => import('photoswipe'),
+    })
+
+    lightbox.on('uiRegister', () => {
+      lightbox?.pswp?.ui?.registerElement({
+        name: 'custom-caption',
+        order: 9,
+        isButton: false,
+        appendTo: 'root',
+        html: '',
+        onInit: (element, pswp) => {
+          pswp.on('change', () => {
+            const trigger = pswp.currSlide?.data.element
+            const caption =
+              trigger instanceof HTMLElement
+                ? trigger.dataset.pswpCaption ||
+                  trigger.querySelector('img')?.getAttribute('alt') ||
+                  ''
+                : ''
+
+            element.textContent = caption
+            element.toggleAttribute('hidden', !caption)
+          })
+        },
+      })
+    })
+
+    lightbox.init()
+  }
+
+  document.addEventListener('astro:page-load', initPhotoSwipe)
+</script>
+
+<style is:global>
+  .pswp__custom-caption {
+    position: absolute;
+    bottom: 1rem;
+    left: 50%;
+    max-width: min(42rem, calc(100vw - 2rem));
+    transform: translateX(-50%);
+    border-radius: 0.375rem;
+    background: rgb(15 15 15 / 72%);
+    padding: 0.375rem 0.75rem;
+    color: white;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    text-align: center;
+    backdrop-filter: blur(10px);
+  }
+
+  .pswp__custom-caption[hidden] {
+    display: none;
+  }
+</style>

--- a/src/generated/image-metadata.ts
+++ b/src/generated/image-metadata.ts
@@ -1,0 +1,11 @@
+type ImageMetadataEntry = {
+  width: number
+  height: number
+  contentType?: string
+}
+
+export const imageMetadata: Record<string, ImageMetadataEntry> = {
+
+}
+
+export type ImageMetadataUrl = keyof typeof imageMetadata

--- a/src/lib/image-metadata.ts
+++ b/src/lib/image-metadata.ts
@@ -1,0 +1,22 @@
+import { imageMetadata } from '@/generated/image-metadata'
+
+const fallbackImageSize = {
+  width: 1600,
+  height: 1000,
+}
+
+export function getImageSize(src: string, width?: number, height?: number) {
+  if (width && height) {
+    return { width, height }
+  }
+
+  const metadata = imageMetadata[src as keyof typeof imageMetadata]
+  if (metadata?.width && metadata.height) {
+    return {
+      width: metadata.width,
+      height: metadata.height,
+    }
+  }
+
+  return fallbackImageSize
+}

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -1,6 +1,7 @@
 ---
 import Breadcrumbs from '@/components/breadcrumbs.astro'
 import Link from '@/components/link.astro'
+import PhotoSwipe from '@/components/photo-swipe.astro'
 import PostHead from '@/components/post-head.astro'
 import PostNavigation from '@/components/post-navigation.astro'
 import SubpostsHeader from '@/components/subposts-header.astro'
@@ -60,6 +61,7 @@ const tocSections = await getTOCSections(currentPostId)
 
 <Layout>
   <PostHead slot="head" post={post} />
+  <PhotoSwipe />
   {
     (hasChildPosts || isCurrentSubpost) && (
       <SubpostsHeader

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,14 @@ export type SocialLink = {
   label: string
 }
 
+export type FigureImage = {
+  src: string
+  alt?: string
+  caption?: string
+  width?: number
+  height?: number
+}
+
 export type IconMap = {
   [key: string]: string
 }


### PR DESCRIPTION
## Summary

- add reusable MDX `Figure` and `ImageGrid` components with PhotoSwipe previews
- add a SQLite-backed `sync:image-metadata` pipeline that scans remote MDX image URLs and writes generated dimensions for stable placeholders
- add VS Code MDX snippets for importing and inserting the new image components

## Privacy

- generated image metadata is empty for the template content
- `data/image-metadata.sqlite` is ignored and not committed
- snippets and README examples use `example.com` URLs only

## Testing

- `npm run build`