### PR TITLE
fix: deduplications, radix colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Below are some fantastic examples of websites based on this template. If you wis
 - $\LaTeX$ math rendered to browser-native and lightweight [MathML](https://developer.mozilla.org/en-US/docs/Web/MathML) via [Temml](https://temml.org/).
 - Subposts for organizing series, rendered as one continuous scrollable document.
 - A fully responsive table of contents with active scrollspy highlighting.
+- Clickable heading anchors for permalinking to any section.
 - GitHub-style callouts/alerts via `:::` directives.
 - SEO optimization with granular metadata and [Open Graph](https://ogp.me/) tag control for each post.
 - [RSS](https://en.wikipedia.org/wiki/RSS) feed and sitemap generation.
@@ -128,18 +129,18 @@ Your site's production URL is configurable in `astro.config.ts` as the `site` fi
 
 ### Color palette
 
-Colors are defined in `src/styles/color.css` in [OKLCH format](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch). Semantic tokens are assigned per scheme with [`light-dark()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/light-dark), so the site respects system preference out of the box and the theme toggle only stores an override:
+Colors are defined in `src/styles/color.css` using the [Radix Colors](https://www.radix-ui.com/colors) scales. Each step carries a light/dark pair via [`light-dark()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/light-dark) and the semantic tokens point at the scale, so the site respects system preference out of the box and the theme toggle only stores an override:
 
 ```css
 :root {
-  --color-neutral-50:  oklch(98.5% 0 0);
+  --gray-1:  light-dark(#fcfcfc, #111111);
   /* ... */
-  --color-neutral-950: oklch(14.5% 0 0);
+  --gray-12: light-dark(#202020, #eeeeee);
 
-  --background:       light-dark(var(--color-neutral-50),  var(--color-neutral-950));
-  --foreground:       light-dark(var(--color-neutral-950), var(--color-neutral-50));
-  --muted-foreground: light-dark(var(--color-neutral-500), var(--color-neutral-400));
-  --border:           light-dark(var(--color-neutral-200), var(--color-neutral-800));
+  --background:       var(--gray-1);
+  --foreground:       var(--gray-12);
+  --muted-foreground: var(--gray-11);
+  --border:           var(--gray-6);
   /* ... */
 
   color-scheme: light dark;
@@ -302,5 +303,5 @@ Built with &hearts; by [enscribe](https://enscribe.dev)!
 
 [Stargazers]: https://img.shields.io/github/stars/jktrn/astro-erudite?color=fafafa&logo=github&logoColor=fff&style=flat
 [Astro Version]: https://img.shields.io/github/package-json/dependency-version/jktrn/astro-erudite/astro?color=0a0a0a&logo=astro&logoColor=fff&style=flat
-[Dependencies]: https://img.shields.io/badge/dependencies-12-fafafa?style=flat
+[Dependencies]: https://img.shields.io/badge/dependencies-13-fafafa?style=flat
 [License]: https://img.shields.io/github/license/jktrn/astro-erudite?color=0a0a0a&logo=github&logoColor=fff&style=flat

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -9,6 +9,7 @@ import { temmlMath } from "./src/lib/math"
 import { calloutDirective } from "./src/lib/callout"
 import { externalLinks } from "./src/lib/external-links"
 import { headingNamespace } from "./src/lib/heading-namespace"
+import { headingAnchors } from "./src/lib/heading-anchors"
 
 export default defineConfig({
   site: "https://astro-erudite.vercel.app",
@@ -26,7 +27,7 @@ export default defineConfig({
     processor: satteri({
       features: { directive: true, math: true },
       mdastPlugins: [calloutDirective, inlineExpressiveCode, temmlMath],
-      hastPlugins: [externalLinks, blockExpressiveCode, headingNamespace],
+      hastPlugins: [externalLinks, blockExpressiveCode, headingNamespace, headingAnchors],
     }),
   },
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-erudite",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/src/components/PostActions.astro
+++ b/src/components/PostActions.astro
@@ -13,6 +13,7 @@ const { prev, next } = Astro.props
 <post-actions>
   <a
     href={prev && `/blog/${prev.id}`}
+    data-icon-button
     data-dir="prev"
     aria-label={prev && `Previous post: ${prev.data.title}`}
     aria-hidden={!prev || undefined}
@@ -22,6 +23,7 @@ const { prev, next } = Astro.props
   </a>
   <a
     href={next && `/blog/${next.id}`}
+    data-icon-button
     data-dir="next"
     aria-label={next && `Next post: ${next.data.title}`}
     aria-hidden={!next || undefined}
@@ -42,22 +44,7 @@ const { prev, next } = Astro.props
   }
 
   a {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 2rem;
-    height: 2rem;
-    border-radius: var(--radius-md);
     color: var(--foreground);
-
-    &:hover {
-      background-color: color-mix(in oklab, var(--muted) 50%, transparent);
-    }
-
-    svg {
-      width: 1rem;
-      height: 1rem;
-    }
 
     &:not([href]) {
       color: var(--muted-foreground);

--- a/src/components/ScrollToTop.astro
+++ b/src/components/ScrollToTop.astro
@@ -7,6 +7,7 @@ const { floating } = Astro.props
 ---
 
 <button
+  data-icon-button
   data-scroll-top
   data-floating={floating || undefined}
   aria-label="Scroll to top"
@@ -16,27 +17,12 @@ const { floating } = Astro.props
 
 <style>
   button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 2rem;
-    height: 2rem;
-    border-radius: var(--radius-md);
     color: var(--foreground);
     visibility: hidden;
 
-    &:hover {
-      background-color: color-mix(in oklab, var(--muted) 50%, transparent);
+    &[data-visible] {
+      visibility: visible;
     }
-
-    svg {
-      width: 1rem;
-      height: 1rem;
-    }
-  }
-
-  :global(body[data-past-title]) button {
-    visibility: visible;
   }
 
   button:not([data-floating]) {
@@ -64,6 +50,18 @@ const { floating } = Astro.props
 </style>
 
 <script>
+  const buttons = [
+    ...document.querySelectorAll<HTMLElement>("[data-scroll-top]"),
+  ]
+
+  const update = () => {
+    const past = scrollY > innerHeight * 0.5
+    for (const button of buttons) button.toggleAttribute("data-visible", past)
+  }
+
+  addEventListener("scroll", update, { passive: true })
+  update()
+
   document.addEventListener("click", (event) => {
     if ((event.target as Element).closest("[data-scroll-top]"))
       window.scrollTo({ top: 0 })

--- a/src/components/SeriesReader.astro
+++ b/src/components/SeriesReader.astro
@@ -103,18 +103,31 @@
   })
 
   const inBand = new Set<Element>()
+
+  const atBottom = () => {
+    const max = document.documentElement.scrollHeight - innerHeight
+    return max > 0 && scrollY >= max - 2
+  }
+
+  const update = () => {
+    const current = atBottom()
+      ? articles[articles.length - 1]
+      : articles.find((article) => inBand.has(article))
+    if (current && current.dataset.url !== normalizePath(location.pathname)) {
+      sync(current)
+    }
+  }
+
   const observer = new IntersectionObserver(
     (entries) => {
       for (const entry of entries) {
         if (entry.isIntersecting) inBand.add(entry.target)
         else inBand.delete(entry.target)
       }
-      const current = articles.find((article) => inBand.has(article))
-      if (current && current.dataset.url !== normalizePath(location.pathname)) {
-        sync(current)
-      }
+      update()
     },
     { rootMargin: "-20% 0px -79% 0px" },
   )
   for (const article of articles) observer.observe(article)
+  addEventListener("scroll", update, { passive: true })
 </script>

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -13,7 +13,7 @@ const section = NAVIGATION.find(
 )
 ---
 
-<aside>
+<aside data-bar>
   <sidebar-inner>
     <a href="/" aria-label={SITE.title}>
       <Logo />
@@ -82,12 +82,6 @@ const section = NAVIGATION.find(
       flex-direction: row;
       align-items: center;
       gap: var(--space-s);
-      padding-block: var(--space-2xs);
-      padding-inline: var(--bar-gutter);
-      background-color: color-mix(in oklab, var(--background) 90%, transparent);
-      backdrop-filter: blur(var(--blur-sm));
-      border-block-end: 2px solid var(--border);
-      border-image: var(--bar-border-image);
     }
   }
 

--- a/src/components/SocialIcons.astro
+++ b/src/components/SocialIcons.astro
@@ -11,6 +11,7 @@ const { links } = Astro.props
       <li>
         <a
           href={href}
+          data-icon-button
           target="_blank"
           rel="noopener noreferrer"
           aria-label={label}
@@ -28,18 +29,11 @@ const { links } = Astro.props
     margin-inline: -0.5rem;
 
     li a {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 2rem;
-      height: 2rem;
       color: var(--muted-foreground);
-      border-radius: var(--radius-md);
       text-decoration: none;
 
       &:hover {
         color: var(--foreground);
-        background-color: color-mix(in oklab, var(--muted) 50%, transparent);
       }
 
       svg {

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -15,7 +15,7 @@ const { title, sections } = Astro.props
 
 <nav aria-label="Table of contents">
   <toc-title aria-hidden="true"><span>{title}</span></toc-title>
-  <label>
+  <label data-bar>
     <input type="checkbox" aria-label="Toggle table of contents">
     <svg viewBox="0 0 16 16" aria-hidden="true">
       <circle cx="8" cy="8" r="6.5" />
@@ -24,21 +24,16 @@ const { title, sections } = Astro.props
     <toc-current>{title}</toc-current>
     <ChevronIcon aria-hidden="true" />
   </label>
-  <ul>
+  <ul data-bar>
     {sections.map(({ id, label, open, headings }) =>
         id ? (
           <li data-group>
             {headings.length > 0 ? (
-              <>
-                <toc-group>
+              <details open={open || undefined}>
+                <summary>
                   <a href={`#${id}`}>{label}</a>
-                  <button
-                    aria-expanded={open ? "true" : "false"}
-                    aria-label={`Toggle ${label} headings`}
-                  >
-                    <ChevronIcon aria-hidden="true" />
-                  </button>
-                </toc-group>
+                  <ChevronIcon aria-hidden="true" />
+                </summary>
                 <ul>
                   {headings.map(({ depth, slug, text }) => (
                     <li data-depth={depth}>
@@ -46,7 +41,7 @@ const { title, sections } = Astro.props
                     </li>
                   ))}
                 </ul>
-              </>
+              </details>
             ) : (
               <a href={`#${id}`}>{label}</a>
             )}
@@ -110,12 +105,6 @@ const { title, sections } = Astro.props
       display: flex;
       align-items: center;
       gap: var(--space-2xs);
-      padding-block: var(--space-2xs);
-      padding-inline: var(--bar-gutter);
-      background-color: color-mix(in oklab, var(--background) 90%, transparent);
-      backdrop-filter: blur(var(--blur-sm));
-      border-block-end: 2px solid var(--border);
-      border-image: var(--bar-border-image);
       cursor: pointer;
 
       input {
@@ -195,12 +184,6 @@ const { title, sections } = Astro.props
       inset-block-start: 100%;
       inset-inline: 0;
       max-block-size: 30svh;
-      padding-block: var(--space-2xs);
-      padding-inline: var(--bar-gutter);
-      background-color: color-mix(in oklab, var(--background) 90%, transparent);
-      backdrop-filter: blur(var(--blur-sm));
-      border-block-end: 2px solid var(--border);
-      border-image: var(--bar-border-image);
     }
   }
 
@@ -231,56 +214,46 @@ const { title, sections } = Astro.props
         margin-block-start: var(--space-2xs);
       }
 
-      toc-group {
-        position: relative;
-        display: block;
-        padding-inline-end: 1.5em;
+      summary {
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+        cursor: pointer;
+        list-style: none;
 
-        a {
-          position: relative;
-          z-index: 1;
+        &::-webkit-details-marker {
+          display: none;
         }
 
-        button {
-          position: absolute;
-          inset: 0;
-          display: flex;
-          align-items: center;
-          justify-content: flex-end;
-          cursor: pointer;
+        a {
+          min-inline-size: 0;
+        }
 
-          svg {
-            flex-shrink: 0;
-            inline-size: 1em;
-            block-size: 1em;
-            color: var(--muted-foreground);
-          }
+        svg {
+          flex-shrink: 0;
+          margin-inline-start: auto;
+          inline-size: 1em;
+          block-size: 1em;
+          color: var(--muted-foreground);
+        }
 
-          &:hover svg {
-            color: var(--foreground);
-          }
-
-          &[aria-expanded="true"] svg {
-            rotate: 180deg;
-          }
+        &:hover svg {
+          color: var(--foreground);
         }
       }
 
-      > ul {
+      details[open] > summary svg {
+        rotate: 180deg;
+      }
+
+      details > ul {
         --shift: 1;
 
-        display: none;
+        margin-block-start: var(--space-3xs);
         font-weight: var(--font-weight-normal);
       }
 
-      &:has(button[aria-expanded="true"]) > ul {
-        display: flex;
-        margin-block-start: var(--space-3xs);
-      }
-
-      &:has(button[aria-expanded="false"]):has(> ul a[data-active])
-        toc-group
-        a {
+      details:not([open]):has(a[data-active]) summary a {
         color: var(--foreground);
       }
     }
@@ -340,14 +313,12 @@ const { title, sections } = Astro.props
     const fallback = currentLabel?.textContent ?? ""
 
     const groups = [
-      ...nav.querySelectorAll<HTMLButtonElement>("li[data-group] button"),
-    ].map((button) => ({
-      button,
-      active: button.getAttribute("aria-expanded") === "true",
+      ...nav.querySelectorAll<HTMLDetailsElement>("li[data-group] details"),
+    ].map((details) => ({
+      details,
+      active: details.open,
       ids: [
-        ...(button
-          .closest("li[data-group]")
-          ?.querySelectorAll<HTMLAnchorElement>("a[href^='#']") ?? []),
+        ...details.querySelectorAll<HTMLAnchorElement>("a[href^='#']"),
       ].map((a) => hashId(a.hash)),
     }))
 
@@ -396,14 +367,6 @@ const { title, sections } = Astro.props
       if (toggle.checked) center()
     })
     list.addEventListener("click", (event) => {
-      const button = (event.target as Element).closest?.("button")
-      if (button) {
-        button.setAttribute(
-          "aria-expanded",
-          button.getAttribute("aria-expanded") === "true" ? "false" : "true",
-        )
-        return
-      }
       if (toggle && (event.target as Element).closest?.("a")) {
         toggle.checked = false
       }
@@ -414,7 +377,6 @@ const { title, sections } = Astro.props
         if (entry.target === heading) {
           const past = !entry.isIntersecting
           title?.toggleAttribute("data-visible", past)
-          document.body.toggleAttribute("data-past-title", past)
         } else if (entry.isIntersecting) visible.add(entry.target)
         else visible.delete(entry.target)
       }
@@ -443,7 +405,7 @@ const { title, sections } = Astro.props
         const active = group.ids.some((id) => activeIds.has(id))
         if (active !== group.active) {
           group.active = active
-          if (active) group.button.setAttribute("aria-expanded", "true")
+          if (active) group.details.open = true
         }
       }
 
@@ -463,7 +425,6 @@ const { title, sections } = Astro.props
       observer.observe(heading)
     } else {
       title?.toggleAttribute("data-visible", true)
-      document.body.toggleAttribute("data-past-title", true)
     }
   })()
 </script>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -3,7 +3,7 @@ import MoonIcon from "@/assets/icons/moon.svg"
 import SunIcon from "@/assets/icons/sun.svg"
 ---
 
-<button id="theme-toggle" aria-label="Toggle theme">
+<button id="theme-toggle" data-icon-button aria-label="Toggle theme">
   <light-icon><SunIcon /></light-icon>
   <dark-icon><MoonIcon /></dark-icon>
 </button>
@@ -40,27 +40,6 @@ import SunIcon from "@/assets/icons/sun.svg"
       dark-icon {
         display: inline;
       }
-    }
-  }
-</style>
-
-<style>
-  button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 2rem;
-    height: 2rem;
-    border-radius: var(--radius-md);
-    cursor: pointer;
-
-    &:hover {
-      background-color: color-mix(in oklab, var(--muted) 50%, transparent);
-    }
-
-    svg {
-      width: 1rem;
-      height: 1rem;
     }
   }
 </style>

--- a/src/content/blog/introducing-v2/index.md
+++ b/src/content/blog/introducing-v2/index.md
@@ -43,8 +43,8 @@ The description of this post claims that v2 is better in every way I know how to
 | | v1 | v2 | Δ |
 | - | -: | -: | -: |
 | JavaScript shipped | 253kb | 6.5kb | <delta-down>↓97%</delta-down> |
-| Largest JavaScript file | 169.8kb <dim-span>(React)</dim-span> | 2.6kb <dim-span>(ToC)</dim-span> | <delta-down>↓98%</delta-down> |
-| CSS shipped | 76kb | 25.5kb | <delta-down>↓66%</delta-down> |
+| Largest JavaScript file | 169.8kb <dim-span>(React)</dim-span> | 2.4kb <dim-span>(ToC)</dim-span> | <delta-down>↓99%</delta-down> |
+| CSS shipped | 76kb | 24.2kb | <delta-down>↓68%</delta-down> |
 | Homepage transfer size | 293kb | 216kb | <delta-down>↓26%</delta-down> |
 | Homepage requests | 14 | 7 | <delta-down>↓50%</delta-down> |
 | Homepage main-thread work | 0.43s | 0.12s | <delta-down>↓72%</delta-down> |
@@ -428,34 +428,35 @@ And that is a complete rundown of astro-erudite's new design system!
 
 #### "If not Tailwind's color system, then what?"
 
-Well, we do still use Tailwind's color system, but it's just imported as pure [`oklch()`](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl) colors:
+[Radix Colors](https://www.radix-ui.com/colors), with each scale carrying a light and dark value per step:
 
 ```css title="src/styles/color.css"
 :root {
-  --color-red-400: oklch(70.4% 0.191 22.216);
-  --color-red-600: oklch(57.7% 0.245 27.325);
+  --gray-1:  light-dark(#fcfcfc, #111111);
+  --gray-2:  light-dark(#f9f9f9, #191919);
+  --gray-3:  light-dark(#f0f0f0, #222222);
+  --gray-4:  light-dark(#e8e8e8, #2a2a2a);
+  --gray-5:  light-dark(#e0e0e0, #313131);
+  --gray-6:  light-dark(#d9d9d9, #3a3a3a);
+  --gray-7:  light-dark(#cecece, #484848);
+  --gray-8:  light-dark(#bbbbbb, #606060);
+  --gray-9:  light-dark(#8d8d8d, #6e6e6e);
+  --gray-10: light-dark(#838383, #7b7b7b);
+  --gray-11: light-dark(#646464, #b4b4b4);
+  --gray-12: light-dark(#202020, #eeeeee);
 
-  --color-neutral-50:  oklch(98.5% 0 0);
-  --color-neutral-100: oklch(97% 0 0);
-  --color-neutral-200: oklch(92.2% 0 0);
-  --color-neutral-300: oklch(87% 0 0);
-  --color-neutral-400: oklch(70.8% 0 0);
-  --color-neutral-500: oklch(55.6% 0 0);
-  --color-neutral-600: oklch(43.9% 0 0);
-  --color-neutral-700: oklch(37.1% 0 0);
-  --color-neutral-800: oklch(26.9% 0 0);
-  --color-neutral-900: oklch(20.5% 0 0);
-  --color-neutral-950: oklch(14.5% 0 0);
+  --red-9:  light-dark(#e5484d, #e5484d);
+  --red-11: light-dark(#ce2c31, #ff9592);
 
-  --background:         light-dark(var(--color-neutral-50),  var(--color-neutral-950));
-  --foreground:         light-dark(var(--color-neutral-950), var(--color-neutral-50));
-  --primary:            light-dark(var(--color-neutral-900), var(--color-neutral-200));
-  --primary-foreground: light-dark(var(--color-neutral-50),  var(--color-neutral-900));
-  --muted:              light-dark(var(--color-neutral-200), var(--color-neutral-800));
-  --muted-foreground:   light-dark(var(--color-neutral-500), var(--color-neutral-400));
-  --destructive:        light-dark(var(--color-red-600),     var(--color-red-400));
-  --border:             light-dark(var(--color-neutral-200), var(--color-neutral-800));
-  --ring:               light-dark(var(--color-neutral-400), var(--color-neutral-500));
+  --background:         var(--gray-1);
+  --foreground:         var(--gray-12);
+  --primary:            var(--gray-12);
+  --primary-foreground: var(--gray-1);
+  --muted:              var(--gray-3);
+  --muted-foreground:   var(--gray-11);
+  --destructive:        var(--red-11);
+  --border:             var(--gray-6);
+  --ring:               var(--gray-8);
 
   color-scheme: light dark;
 }
@@ -988,11 +989,11 @@ prose-content {
     }
   }
 
-  [data-callout="note"]      { --accent: oklch(62.3% 0.214 259.815); }
-  [data-callout="tip"]       { --accent: oklch(72.3% 0.219 149.579); }
-  [data-callout="warning"]   { --accent: oklch(76.9% 0.188 70.08);   }
-  [data-callout="caution"]   { --accent: oklch(63.7% 0.237 25.331);  }
-  [data-callout="important"] { --accent: oklch(62.7% 0.265 303.9);   }
+  [data-callout="note"]      { --accent: #0090ff; }
+  [data-callout="tip"]       { --accent: #30a46c; }
+  [data-callout="warning"]   { --accent: #ffc53d; }
+  [data-callout="caution"]   { --accent: #e5484d; }
+  [data-callout="important"] { --accent: #8e4ec6; }
 }
 ```
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,6 +10,8 @@ import "@/styles/typography-block.css"
 import "@/styles/typography-tables.css"
 import "@/styles/callout.css"
 import "@/styles/layout.css"
+import "@/styles/icon-button.css"
+import "@/styles/bar.css"
 import "@/styles/shape.css"
 
 import Footer from "@/components/Footer.astro"

--- a/src/lib/heading-anchors.ts
+++ b/src/lib/heading-anchors.ts
@@ -1,0 +1,31 @@
+import GithubSlugger from "github-slugger"
+import { h } from "hastscript"
+import { defineHastPlugin } from "satteri"
+
+export function headingAnchors() {
+  const slugger = new GithubSlugger()
+  return defineHastPlugin({
+    name: "heading-anchors",
+    element: {
+      filter: ["h2", "h3", "h4", "h5", "h6"],
+      visit(node, ctx) {
+        const existing = node.properties.id
+        const id =
+          typeof existing === "string" && existing
+            ? existing
+            : slugger.slug(ctx.textContent(node))
+        if (!id) return
+        if (existing !== id) ctx.setProperty(node, "id", id)
+        ctx.appendChild(
+          node,
+          h("a", {
+            dataHeadingAnchor: "",
+            href: `#${id}`,
+            ariaLabel: "Link to this section",
+            tabIndex: -1,
+          }),
+        )
+      },
+    },
+  })
+}

--- a/src/styles/bar.css
+++ b/src/styles/bar.css
@@ -1,0 +1,10 @@
+[data-bar] {
+  @media (width < 64rem) {
+    padding-block: var(--space-2xs);
+    padding-inline: var(--bar-gutter);
+    background-color: color-mix(in oklab, var(--background) 90%, transparent);
+    backdrop-filter: blur(var(--blur-sm));
+    border-block-end: 2px solid var(--border);
+    border-image: var(--bar-border-image);
+  }
+}

--- a/src/styles/callout.css
+++ b/src/styles/callout.css
@@ -24,6 +24,10 @@ prose-content {
         display: none;
       }
 
+      :is(strong, b) {
+        color: inherit;
+      }
+
       svg {
         flex-shrink: 0;
         inline-size: 1.25rem;
@@ -61,9 +65,9 @@ prose-content {
     }
   }
 
-  [data-callout="note"]      { --accent: oklch(62.3% 0.214 259.815); }
-  [data-callout="tip"]       { --accent: oklch(72.3% 0.219 149.579); }
-  [data-callout="warning"]   { --accent: oklch(76.9% 0.188 70.08);   }
-  [data-callout="caution"]   { --accent: oklch(63.7% 0.237 25.331);  }
-  [data-callout="important"] { --accent: oklch(62.7% 0.265 303.9);   }
+  [data-callout="note"]      { --accent: #0090ff; }
+  [data-callout="tip"]       { --accent: #30a46c; }
+  [data-callout="warning"]   { --accent: #ffc53d; }
+  [data-callout="caution"]   { --accent: #e5484d; }
+  [data-callout="important"] { --accent: #8e4ec6; }
 }

--- a/src/styles/color.css
+++ b/src/styles/color.css
@@ -1,28 +1,29 @@
 :root {
-  --color-red-400: oklch(70.4% 0.191 22.216);
-  --color-red-600: oklch(57.7% 0.245 27.325);
+  --gray-1:  light-dark(#fcfcfc, #111111);
+  --gray-2:  light-dark(#f9f9f9, #191919);
+  --gray-3:  light-dark(#f0f0f0, #222222);
+  --gray-4:  light-dark(#e8e8e8, #2a2a2a);
+  --gray-5:  light-dark(#e0e0e0, #313131);
+  --gray-6:  light-dark(#d9d9d9, #3a3a3a);
+  --gray-7:  light-dark(#cecece, #484848);
+  --gray-8:  light-dark(#bbbbbb, #606060);
+  --gray-9:  light-dark(#8d8d8d, #6e6e6e);
+  --gray-10: light-dark(#838383, #7b7b7b);
+  --gray-11: light-dark(#646464, #b4b4b4);
+  --gray-12: light-dark(#202020, #eeeeee);
 
-  --color-neutral-50:  oklch(98.5% 0 0);
-  --color-neutral-100: oklch(97% 0 0);
-  --color-neutral-200: oklch(92.2% 0 0);
-  --color-neutral-300: oklch(87% 0 0);
-  --color-neutral-400: oklch(70.8% 0 0);
-  --color-neutral-500: oklch(55.6% 0 0);
-  --color-neutral-600: oklch(43.9% 0 0);
-  --color-neutral-700: oklch(37.1% 0 0);
-  --color-neutral-800: oklch(26.9% 0 0);
-  --color-neutral-900: oklch(20.5% 0 0);
-  --color-neutral-950: oklch(14.5% 0 0);
+  --red-9:  light-dark(#e5484d, #e5484d);
+  --red-11: light-dark(#ce2c31, #ff9592);
 
-  --background:         light-dark(var(--color-neutral-50),  var(--color-neutral-950));
-  --foreground:         light-dark(var(--color-neutral-950), var(--color-neutral-50));
-  --primary:            light-dark(var(--color-neutral-900), var(--color-neutral-200));
-  --primary-foreground: light-dark(var(--color-neutral-50),  var(--color-neutral-900));
-  --muted:              light-dark(var(--color-neutral-200), var(--color-neutral-800));
-  --muted-foreground:   light-dark(var(--color-neutral-500), var(--color-neutral-400));
-  --destructive:        light-dark(var(--color-red-600),     var(--color-red-400));
-  --border:             light-dark(var(--color-neutral-200), var(--color-neutral-800));
-  --ring:               light-dark(var(--color-neutral-400), var(--color-neutral-500));
+  --background:         var(--gray-1);
+  --foreground:         var(--gray-12);
+  --primary:            var(--gray-12);
+  --primary-foreground: var(--gray-1);
+  --muted:              var(--gray-3);
+  --muted-foreground:   var(--gray-11);
+  --destructive:        var(--red-11);
+  --border:             var(--gray-6);
+  --ring:               var(--gray-8);
 
   color-scheme: light dark;
 }

--- a/src/styles/icon-button.css
+++ b/src/styles/icon-button.css
@@ -1,0 +1,18 @@
+[data-icon-button] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+
+  &:hover {
+    background-color: color-mix(in oklab, var(--muted) 50%, transparent);
+  }
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
+}

--- a/src/styles/typography-headings.css
+++ b/src/styles/typography-headings.css
@@ -11,6 +11,33 @@ prose-content {
     }
   }
 
+  :is(h2, h3, h4, h5, h6) {
+    [data-heading-anchor] {
+      margin-inline-start: 0.5ch;
+      color: var(--muted-foreground);
+      text-decoration-line: none;
+      opacity: 0;
+
+      &::before {
+        content: "#";
+      }
+
+      &:hover {
+        color: var(--foreground);
+      }
+    }
+
+    &:is(:hover, :target) [data-heading-anchor] {
+      opacity: 1;
+    }
+
+    @media (hover: none) {
+      [data-heading-anchor] {
+        opacity: 1;
+      }
+    }
+  }
+
   h1 {
     font-size: var(--step-3);
   }


### PR DESCRIPTION
## Summary

A maintenance pass backported from the erudocs work:

- **Shared primitives** — `[data-icon-button]` (`icon-button.css`) and `[data-bar]` (`bar.css`) replace box CSS that was duplicated across `ThemeToggle`, `SocialIcons`, `PostActions`, and `ScrollToTop`.
- **Radix colors** — `color.css` switches to the Radix gray + red scales via `light-dark()`; callout accents updated to match.
- **Heading anchors** — `[data-heading-anchor]` section permalinks on `h2`–`h6`.
- **Fixes** — native `<details>` ToC groups, Firefox-safe `ScrollToTop` (scroll listener, not scroll-driven animation), `SeriesReader` bottom-of-page sync.
- **Docs** — `introducing-v2` and the README updated for the Radix switch; bundle metrics re-measured; dependencies badge corrected (12 → 13).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jktrn/astro-erudite/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->